### PR TITLE
Logo href configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The configuration file follows a simple structure.
 {
     "title": "Title shown at the top of the app.",
     "logoLocation": "Image location of the logo shown at the top of the app (relative to public folder.).",
-    "logoRedirectURL": "The URL the Web application redirects to when a users clicks on the logo.",
+    "logoRedirectURL": "The URL the Web application redirects to when a user clicks on the logo.",
     "mainAppColor": "The main colors used in the app, can be any CSS color.",
     "backgroundColor": "Background color of the app, can be any CSS color.",
     "footer": "HTML components or text that will function as the footer (will be placed in the footer div.)",

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The configuration file follows a simple structure.
 {
     "title": "Title shown at the top of the app.",
     "logoLocation": "Image location of the logo shown at the top of the app (relative to public folder.).",
+    "logoRedirectURL": "The URL the Web application redirects to when a users clicks on the logo.",
     "mainAppColor": "The main colors used in the app, can be any CSS color.",
     "backgroundColor": "Background color of the app, can be any CSS color.",
     "footer": "HTML components or text that will function as the footer (will be placed in the footer div.)",

--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,7 @@ function App() {
   return (
     <div className="App" style={{backgroundColor: config.backgroundColor}}>
       <header>
-        <img alt="Logo of the Web app" className="logo" src={config.logoLocation}></img>
+        <a href={config.logoRedirectURL} target="_blank" rel="noreferrer"><img alt="Logo of the Web app" className="logo" src={config.logoLocation}></img></a>
         <h1 className="app-title">{config.title}</h1>
       </header>
       <div className="app-body">

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,7 @@
 {
     "title": "Generic Data Viewer",
     "logoLocation": "images/IDLab-logo.jpg",
+    "logoRedirectURL": "https://idlab.technology/",
     "mainAppColor": "lightgray", 
     "backgroundColor": "#fff",
     "queryFolder": "queries",


### PR DESCRIPTION
This PR resolves #44 : 

- Added instructions in [README.md](https://github.com/SolidLabResearch/generic-data-viewer/compare/logo-href-configuration?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to set the redirect URL. 
- Configured a default logo href